### PR TITLE
Add instructions for running on NixOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ Read up on Bazel [Concepts and Terminology][concepts].
 
 [concepts]: https://docs.bazel.build/versions/main/build-ref.html
 
+## Running on NixOS
+
+If you're running NixOS you're going to have to apply [a patch][rules_proto_nixos_patch] to `rules_proto`,
+because they're currently using a prebuilt compiler, in which the linker is hardcoded to `/lib64/ld-linux-x86-64.so.2`.
+The patch will instead force `rules_proto` to rebuild `protoc`, so we can link it properly.
+Note that this solution is not ideal: optimally we would be getting `protoc` from `nixpkgs` and hooking it into `rules_proto`.
+
+See [this issue][rules_proto_protoc_issue] for a discussion on the topic.
+
+Hint: `http_archive` [supports][http_archive_attributes] applying patches to whatever it downloads.
+
+[rules_proto_nixos_patch]: patches/rules_proto/nixos.patch
+[http_archive_attributes]: https://bazel.build/rules/lib/repo/http#attributes
+[rules_proto_protoc_issue]: https://github.com/bazelbuild/rules_proto/issues/115
+
 ## Install Nix and enter `nix-shell`
 
 Install the [Nix package manager](https://nixos.org/explore.html) with

--- a/patches/rules_proto/nixos.patch
+++ b/patches/rules_proto/nixos.patch
@@ -1,0 +1,23 @@
+diff --git a/proto/private/BUILD.release b/proto/private/BUILD.release
+index 4c2a43f..b37d83c 100644
+--- a/proto/private/BUILD.release
++++ b/proto/private/BUILD.release
+@@ -3,17 +3,7 @@ load("@rules_proto//proto:defs.bzl", "proto_lang_toolchain")
+ # Use precompiled binaries where possible.
+ alias(
+     name = "protoc",
+-    actual = select({
+-        ":linux-aarch64": "@com_google_protobuf_protoc_linux_aarch64//:protoc",
+-        ":linux-ppc": "@com_google_protobuf_protoc_linux_ppc//:protoc",
+-        ":linux-s390x": "@com_google_protobuf_protoc_linux_s390_64//:protoc",
+-        ":linux-x86_32": "@com_google_protobuf_protoc_linux_x86_32//:protoc",
+-        ":linux-x86_64": "@com_google_protobuf_protoc_linux_x86_64//:protoc",
+-        ":macos-x86_64": "@com_google_protobuf_protoc_macos_x86_64//:protoc",
+-        ":windows-x86_32": "@com_google_protobuf_protoc_windows_x86_32//:protoc",
+-        ":windows-x86_64": "@com_google_protobuf_protoc_windows_x86_64//:protoc",
+-        "//conditions:default": "@com_github_protocolbuffers_protobuf//:protoc",
+-    }),
++    actual = "@com_github_protocolbuffers_protobuf//:protoc",
+     visibility = ["//visibility:public"],
+ )
+ 


### PR DESCRIPTION
rules_proto doesn't work out of the box so we need to patch it.