### PR TITLE
Ignore .direnv directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bazel-*
 node_modules/
 user.bazelrc
+/.direnv


### PR DESCRIPTION
Ignore the `.direnv` directory which gets created by [nix-direnv](https://github.com/nix-community/nix-direnv).