### PR TITLE
Make it easier to use the project on NixOS

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -70,6 +70,9 @@ rules_cc_toolchains()
 # BEGIN: Protobuf dependencies
 http_archive(
     name = "rules_proto",
+    # !! uncomment the following two lines if you're using NixOS !!
+    #patch_args = ["-p1"],
+    #patches = ["@//:patches/rules_proto/nixos.patch"],
     sha256 = "66bfdf8782796239d3875d37e7de19b1d94301e8972b3cbd2446b332429b4df1",
     strip_prefix = "rules_proto-4.0.0",
     urls = [


### PR DESCRIPTION
This PR simply adds a commented patch which should be uncommented (as per the instructions in the comment above) when using the codelab on NixOS.

See also #9.
