### PR TITLE
Move buildInputs into packages

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -6,6 +6,5 @@ in
 with pkgs;
 
 mkShell {
-  buildInputs = [ bazel_4 buildifier buildozer nix ];
-  packages = [ lab-script ];
+  packages = [ lab-script bazel_4 buildifier buildozer nix ];
 }


### PR DESCRIPTION
Moving Nix Shell's buildInputs into the package attribute causes the completion packages to also be added to the
shell. This is nice since it means I can do `bazel <TAB>` and it actually autocompletes.