### PR TITLE
Add CI to test bazel build

### DIFF
--- a/.github/workflows/bazel-build.yml
+++ b/.github/workflows/bazel-build.yml
@@ -1,0 +1,17 @@
+name: bazel-build
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  build-bazel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v15
+        with:
+          nix_path: nixpkgs=channel:nixos-22.05
+      - run: bin/lab install_all
+      - run: nix-shell --pure --run "bazel test //..."


### PR DESCRIPTION
This PR adds a simple CI through GitHub worksflows, it boots into a Nix capable linux system and uses the `lab` script to install the "solutions" files from the Codelab to make it ready to compile.