### PR TITLE
Explain additional required java dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Build a Java client which sends log messages to the server, in the format define
         - name it `JavaLoggingClientLibrary`
         - use `JavaLoggingClientLibrary.java` as source
         - declare depencies on `*_proto` and `*_grpc` targets created in previous steps
-        - TODO: explain additional dependencies
+        - since `JavaLoggingClientLibrary` uses the `io.grpc` package, you will also need to declare a dependency on `@io_grpc_grpc_java//core`, as well as a transport impementation such as `@io_grpc_grpc_java//netty`.
     2. Add a Java binary for the client
         - use [`java_binary()`](https://docs.bazel.build/versions/4.2.1/be/java.html#java_binary)
         - name it `JavaLoggingClient`


### PR DESCRIPTION
While working through the codelab I noticed a TODO about explaining the additional required dependencies for `javaLoggingClientLibrary`. Since this step had confused me while completing the exercise, I thought I'd try to add a short explanation.