### PR TITLE
Fix the link target for the tags documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Build a Java client which sends log messages to the server, in the format define
 1.  Run the test using `bazel test` and make sure that it passes
 1.  Run the test multiple times using `bazel test <target> --runs_per_test=10`
     - Does it pass? If not, can you figure out why?
-    - Hint: the section on test run behaviour in the [`tags` documentation](tags_docs) may prove useful.
+    - Hint: the section on test run behaviour in the [`tags` documentation][tags_docs] may prove useful.
 
 [sh_test]: https://docs.bazel.build/versions/4.2.1/be/shell.html#sh_test
 [tags_docs]: https://docs.bazel.build/versions/4.2.1/be/common-definitions.html#common.tags


### PR DESCRIPTION
The original PR used parentheses which end up linking to a nonexistent file in our repository. This commit uses brackets to instead use reference at the end of the section.