### PR TITLE
Add exercise number in the solutions

### DIFF
--- a/solutions/go/cmd/server/BUILD.bazel
+++ b/solutions/go/cmd/server/BUILD.bazel
@@ -1,11 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
-go_binary(
-    name = "go-server",
-    embed = [":server_lib"],
-    visibility = ["//visibility:public"],
-)
-
 go_library(
     name = "server_lib",
     srcs = ["server.go"],
@@ -17,4 +11,12 @@ go_library(
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//reflection",
     ],
+)
+
+# section 2 code added here
+
+go_binary(
+    name = "go-server",
+    embed = [":server_lib"],
+    visibility = ["//visibility:public"],
 )

--- a/solutions/java/src/main/java/bazel/bootcamp/BUILD.bazel
+++ b/solutions/java/src/main/java/bazel/bootcamp/BUILD.bazel
@@ -1,9 +1,13 @@
 load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_test")
 
+# section 1 code added here
+
 java_binary(
     name = "HelloBazelBootcamp",
     srcs = ["HelloBazelBootcamp.java"],
 )
+
+# section 3 code added here
 
 java_library(
     name = "JavaLoggingClientLibrary",
@@ -22,6 +26,8 @@ java_binary(
     deps = [":JavaLoggingClientLibrary"],
     visibility = ["//visibility:public"]
 )
+
+# section 4 code added here
 
 java_test(
     name = "JavaLoggingClientLibraryTest",

--- a/solutions/proto/logger/BUILD.bazel
+++ b/solutions/proto/logger/BUILD.bazel
@@ -6,6 +6,8 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])
 
+# section 2 code added here
+
 proto_library(
     name = "logger_proto",
     srcs = ["logger.proto"]
@@ -18,6 +20,8 @@ go_proto_library(
     importpath = "bootcamp/proto/logger"
 )
 
+# section 3 code added here
+
 java_proto_library(
     name = "logger_java_proto",
     deps = [":logger_proto"]
@@ -28,6 +32,8 @@ java_grpc_library(
     srcs = [":logger_proto"],
     deps = [":logger_java_proto"],
 )
+
+# section 5 code added here
 
 ts_proto_library(
     name = "logger_ts_proto",

--- a/solutions/tests/BUILD.bazel
+++ b/solutions/tests/BUILD.bazel
@@ -1,3 +1,5 @@
+# section 6 code added here
+
 sh_test(
     name = "integration_test",
     srcs = ["integrationtest.sh"],

--- a/solutions/typescript/BUILD.bazel
+++ b/solutions/typescript/BUILD.bazel
@@ -1,11 +1,9 @@
 load("@npm//@bazel/concatjs:index.bzl", "concatjs_devserver")
 load("@npm//@bazel/typescript:index.bzl", "ts_library")
 
-concatjs_devserver(
-    name = "devserver",
-    entry_module = "bootcamp/typescript/app",
-    deps = [":app"],
-)
+exports_files(["tsconfig.json"])
+
+# section 5 code added here
 
 ts_library(
     name = "app",
@@ -15,4 +13,8 @@ ts_library(
     ],
 )
 
-exports_files(["tsconfig.json"])
+concatjs_devserver(
+    name = "devserver",
+    entry_module = "bootcamp/typescript/app",
+    deps = [":app"],
+)

--- a/typescript/BUILD.bazel
+++ b/typescript/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@npm//@bazel/concatjs:index.bzl", "concatjs_devserver")
 load("@npm//@bazel/typescript:index.bzl", "ts_library")
 
-# section 5 code to add here
-
 exports_files(["tsconfig.json"])
+
+# section 5 code to add here


### PR DESCRIPTION
I expect it to simplify the reader navigation to the code base.
Especially if one runs `lab install ANY_FOLDER/BUILD.bazel` while doing one of the first exercises, it helps to identify which lines are related to the exercise they are trying to solve.