### PR TITLE
Java client tests should fail when the server is not running

### DIFF
--- a/.github/workflows/bazel-build.yml
+++ b/.github/workflows/bazel-build.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-22.05
       - run: bin/lab install_all
-      - run: nix-shell --pure --run "bazel test //..."
+      - run: nix-shell --pure --run "bazel test //tests:integration_test"

--- a/README.md
+++ b/README.md
@@ -214,12 +214,20 @@ Build a Java client which sends log messages to the server, in the format define
         - add `JavaLoggingClientLibrary` target from [Section 3](#section-3-java-client) as dependency
     2. Repeat the same for the client binary `JavaLoggingClient`
 1.  Run tests
-    - TODO: this is not a unit test, it depends on the server to make any sense (but passes without it, throwing an error message)! write a mock?
+    - NOTE: this is not a unit test, it depends on the server to make any sense.
+        - If you skipped section 2 exercise, you can simply run `lab install go/cmd/server/BUILD.bazel` to get the solution of this exercise and `bazel run //go/cmd/server:go-server` to run it.
     - start Go server in another `nix-shell`, as in [Section 2](#section-2-go-server)
     - run Java client tests
       ```
       bazel test //java/src/main/java/bazel/bootcamp:JavaLoggingClientLibraryTest
       ```
+        - NOTE: If you simply turn off the server and rerun the test,
+            you will most likely see that the test passed, with the information that it is "cached".
+            Indeed, Bazel does not rerun the tests if none of its dependencies changed.
+            If you really want to rerun it to acknowledge that it fails when the server is off,
+            you have to specify `--cache_test_results=no` in the command line.
+    - Do not forget to run the tests of `JavaLoggingClient`
+        - NOTE: Those tests do not use the server.
 
 ## Section 5: Typescript web frontend
 

--- a/java/src/main/java/bazel/bootcamp/JavaLoggingClientLibrary.java
+++ b/java/src/main/java/bazel/bootcamp/JavaLoggingClientLibrary.java
@@ -36,12 +36,7 @@ public class JavaLoggingClientLibrary {
   public void sendLogMessageToServer(String message) {
     logger.info("Trying to send message '" + message + "' to server...");
     LogMessage logMessage = LogMessage.newBuilder().setMessage(message).build();
-    try {
-      blockingStub.sendLogMessage(logMessage);
-    } catch (StatusRuntimeException e) {
-      logger.log(Level.WARNING, "RPC failed: {0}", e.getStatus());
-      return;
-    }
+    blockingStub.sendLogMessage(logMessage);
   }
 
 }


### PR DESCRIPTION
I think that it is much clearer if the client test fails when no server is running rather than having a test which simply states pass whereas the client is talking to a wall, and then the user adds the `--test_output=all` and discovers that the test is green whereas the log contains an horrible error message.
Plus, it is an opportunity to talking about test caching.