### PR TITLE
Remove mention to Gazelle in the project

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,24 +1,8 @@
-load("@bazel_gazelle//:def.bzl", "gazelle")
-
 package(default_visibility = ["//visibility:public"])
 
 alias(
     name = "tsconfig.json",
     actual = "//typescript:tsconfig.json",
-)
-
-# gazelle:prefix github.com/bazelbuild/codelabs
-gazelle(name = "gazelle")
-
-gazelle(
-    name = "gazelle-update-repos",
-    args = [
-        "-from_file=go.mod",
-        "-to_macro=deps.bzl%go_dependencies",
-        "-prune",
-        "-build_file_proto_mode=disable_global",
-    ],
-    command = "update-repos",
 )
 
 # section 7 code to add here

--- a/README.md
+++ b/README.md
@@ -13,12 +13,10 @@ It has been adapted to
 
 - Use more recent versions of the required Bazel rule sets.
 - Follow best practices such as formatting with [`buildifier`][buildifier] or using `BUILD.bazel` files instead of `BUILD` files.
-- Manage Go dependencies and targets using [Gazelle][gazelle].
 - Use [Nix][nix] to provide Bazel and other developer tools in a Nix shell.
 - Use [`rules_nixpkgs`][rules_nixpkgs] to import Nix provided toolchains from [`nixpkgs`][nixpkgs].
 
 [buildifier]: https://github.com/bazelbuild/buildtools/blob/master/buildifier/README.md
-[gazelle]: https://github.com/bazelbuild/bazel-gazelle
 [nix]: https://nixos.org/
 [rules_nixpkgs]: https://github.com/tweag/rules_nixpkgs
 [nixpkgs]: https://github.com/NixOS/nixpkgs

--- a/solutions/BUILD.bazel
+++ b/solutions/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 
 package(default_visibility = ["//visibility:public"])
@@ -6,20 +5,6 @@ package(default_visibility = ["//visibility:public"])
 alias(
     name = "tsconfig.json",
     actual = "//typescript:tsconfig.json",
-)
-
-# gazelle:prefix github.com/bazelbuild/codelabs
-gazelle(name = "gazelle")
-
-gazelle(
-    name = "gazelle-update-repos",
-    args = [
-        "-from_file=go.mod",
-        "-to_macro=deps.bzl%go_dependencies",
-        "-prune",
-        "-build_file_proto_mode=disable_global",
-    ],
-    command = "update-repos",
 )
 
 # section 7 code added here


### PR DESCRIPTION
In this pull request, I consider that Gazelle is considered completely out of the scope of this tutorial. There were 2 mentions of it in the README, one in the mention of the difference with the Google codelab and the other one in a TODO. Furthermore, running gazelle modified all the solution files, so I do not think that it is something we want to mention here. (But it is worth a specific tutorial, which probably already exists somewhere).

closes #40 
closes #15